### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+name 'locales'
+
+run_list 'test::default'
+
+cookbook 'locales', path: '.'
+cookbook 'test', path: 'test/cookbooks/test'
+
+Dir.entries('./test/cookbooks/test/recipes').select { |f| f.end_with?('.rb') }.each do |test|
+  test = test.delete_suffix('.rb')
+  named_run_list :"#{test}", "test::#{test}"
+end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -44,8 +44,10 @@ suites:
     run_list: *default_run_list
     verifier: *default_verifier
   - name: de-at-utf8
-    run_list: *de_at_utf8_run_list
+    provisioner:
+      named_run_list: de_at_utf8
     verifier: *de_at_utf8_verifier
   - name: multiple
-    run_list: *multiple_run_list
+    provisioner:
+      named_run_list: multiple
     verifier: *multiple_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- replace Berksfile with Policyfile.rb
- switch ChefSpec to Policyfile support
- update Copilot setup to run chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list